### PR TITLE
Groom support

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,20 +52,21 @@ It is highly recommended to install `tesseract` app when using `visual-lookup` m
 
 # How it works
 - Prepare your assets upfront and save them as a `*.duf` files. DTH-AutoTool app uses `Asset Manager` API to locate the assets. Your *.duf files are automatically added to DAZ database. Manually copied `*.duf` files to common DAZ directories can be browsed from UI as files but are not part of database automatically (scanning files is not supported in DTH-AutoTool at the moment). The easiest way to index them is to add assets to existing categories or for example create entirely new category (e.g. DTH category from the entire _DazToHue_ folder).
-- In `project.config.json` under `templates` section, list all templates with their `character`, `clothing` and/or `morphs` subsections. None of them is mandatory for template, which means you can split different layers across templates and combine them later in `exportables` section. Every template name must be unique.
-- `character`, `clothing` and/or `morphs` subsections contains _layer groups_. Every _layer group_ must have a globally unique name and contains array of layers (`*duf` files) that logically belongs together (for example, some parts of clothings may exist as separate DAZ assets, but you may want to handle it as a single group/unit - single outfit).
-- `templates` can only be referenced in `exportables`. Exportables are producing real outpus. You can combine several templates together in one exportable and _override_ specific layer groups, _prepend_ or _append_ to them, or completely _replace_ entire `character`, `clothing` or `morphs` sections if needed. This provides higher granularity in setting up specific characters/figures to export.
+- In `project.config.json` under `templates` section, list all templates with their `character`, `clothing`, `grooming` and/or `morphs` subsections. None of them is mandatory for template, which means you can split different layers across templates and combine them later in `exportables` section. Every template name must be unique.
+- `character`, `clothing`, `grooming` and/or `morphs` subsections contains _layer groups_. Every _layer group_ must have a globally unique name and contains array of layers (`*duf` files) that logically belongs together (for example, some parts of clothings may exist as separate DAZ assets, but you may want to handle it as a single group/unit - single outfit).
+- `templates` can only be referenced in `exportables`. Exportables are producing real outpus. You can combine several templates together in one exportable and _override_ specific layer groups, _prepend_ or _append_ to them, or completely _replace_ entire `character`, `clothing`, `grooming` or `morphs` sections if needed. This provides higher granularity in setting up specific characters/figures to export.
 
 ### Character vs. Clothing vs. Morphs
 - `character` layers are applied first and should define the characters basic look. If you need, you can apply also clothing `*.duf` files but the idea of these layers is their single appliance at the beginning of the pipeline.
 - `clothing` layers are applied after the `character` layers but **always only one clothing** per pipeline run. After one of the clothings is applied, `morphs` layers are loaded.
+- `grooming` layers are applied after the `character` layers but **always only one grooming** per pipeline run. `morphs` layers are _not_ loaded with groomings. Character is hidden and timeline is shrunk to minimize output file size. **Only alembic cache** is exported for grooming assets. Subdivision is also reduced to 0-level as it is better to increase it on-demand later in Houdini part of DTH workflow.
 - `morphs` layers are loaded after `clothing` and usually should contain timeline JCM frames or morphs to be handled by DTH workflow.
 - Once layers are loaded, export is triggered. Then the process is repeated for each available `clothing`.
 
 ### Edit mode
 - If you need to load only the layers without export being triggered, use `edit_mode` configuration section.
 - Set `is_enabled` to `true` and specify `exportable_name` to valid value.
-- If `exportable` has clothing layers, you can also specify `clothing_name` to load.
+- If `exportable` has clothing layers, you can also specify `clothing_name` or `grooming_name` to load.
 
 ### Export filter patterns
 Can be used to narrow down list of exportables and clothings to export (for example if you change only some of them and need to re-export again).
@@ -77,7 +78,7 @@ You can use [regex101.com] to test your regular expression (make sure you are us
 - `exportables`: filters by exportable names.
 - `templates`: filters by template names.
 - `layers`: filters by layer values (e.g. `duf` files) across all exportables/templates. Only exportables with matched layer values will be entirely exported.
-- `clothing`: this filter pattern can be used to export only matched clothings.
+- `accessories`: this filter is applied on all accessories (clothings and groomings) at the same time. Only matched layer groups will be exported not entire exportables.
 
 # How to compile
 This project depends on [robotgo](https://github.com/go-vgo/robotgo) and [gocv](https://github.com/vcaesar/gcv) libraries.

--- a/example/config/project.config.json
+++ b/example/config/project.config.json
@@ -10,7 +10,7 @@
         "export_patterns": {
             "exportables": "",
             "templates": "",
-            "clothing": "",
+            "accessories": "",
             "layers": ""
         },
         "sagan_alembic_export_directory": "../temp/abc",

--- a/example/config/project.config.json
+++ b/example/config/project.config.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.1",
+    "version": "0.2",
     "edit_mode": {
         "is_enabled": false,
         "exportable_name": "",
@@ -24,20 +24,29 @@
     },
     "templates": [
         {
-            "name": "Default Female",
-            "character": [ { "name": "Genesis 8.1 Basic Female", "layers": ["genesis 8.1 basic female.duf"] } ],
-            "clothing": [ { "name": "Basic Female Wear", "layers": ["basic wear tank top.duf", "basic wear shorts.duf"] } ],
+            "name": "Default Male",
+            "character": [ { "name": "Genesis 8.1 Male", "layers": ["genesis 8.1 basic male.duf"] } ],
             "morphs": [ { "name": "DTH", "layers": ["G8.1 LINEAR JCM - Base.duf"] } ]
         },
         {
-            "name": "Default Male",
-            "character": [ { "name": "Genesis 8.1 Male", "layers": ["genesis 8.1 basic male.duf"] } ],
-            "clothing": [ { "name": "Basic Male Wear", "layers": ["basic wear t shirt.duf", "basic wear boxers.duf"] } ],
+            "name": "Default Female",
+            "character": [ { "name": "Genesis 8.1 Basic Female", "layers": ["genesis 8.1 basic female.duf"] } ],
             "morphs": [ { "name": "DTH", "layers": ["G8.1 LINEAR JCM - Base.duf"] } ]
+        },
+
+        {
+            "name": "Default Male Accessories",
+            "clothing": [ { "name": "Basic Male Wear", "layers": ["basic wear t shirt.duf", "basic wear boxers.duf"] } ],
+            "grooming": [ { "name": "Basic Male Hair", "layers": ["Armani Hair.duf"] } ]
+        },
+        {
+            "name": "Default Female Accessories",
+            "clothing": [ { "name": "Basic Female Wear", "layers": ["basic wear tank top.duf", "basic wear shorts.duf"] } ],
+            "grooming": [ { "name": "Basic Female Hair", "layers": ["Toulouse Hair.duf"] } ]
         }
     ],
     "exportables": [
-        { "name": "Adam", "templates": ["Default Male"] },
-        { "name": "Eve", "templates": ["Default Female"] }
+        { "name": "Adam", "templates": [ "Default Male", "Default Male Accessories" ] },
+        { "name": "Eve", "templates": [ "Default Female", "Default Female Accessories" ] }
     ]
 }

--- a/main.go
+++ b/main.go
@@ -70,7 +70,7 @@ func main() {
 				LoadSaganConfigWindowTitle:          "Select Config File",
 				LoadSaganConfigWindowMaxWaitSeconds: 10,
 				ExpProgressWindowTitle:              "Export Progress",
-				ExpProgressWindowMaxWaitSeconds:     10,
+				ExpProgressWindowMaxWaitSeconds:     5,
 				MaxExportDurationMinutes:            5,
 				TimelineEndFrame:                    DthAutoToolCmdOptions.EndFrame,
 				OutputPath:                          DthAutoToolCmdOptions.SaganOutputPath,

--- a/scripts/dth_at_config.dsa
+++ b/scripts/dth_at_config.dsa
@@ -84,15 +84,9 @@ Object.defineProperty( DthAutoToolExportPatternsConfig.prototype, "templates", {
     }
 } );
 
-Object.defineProperty( DthAutoToolExportPatternsConfig.prototype, "clothing", {
+Object.defineProperty( DthAutoToolExportPatternsConfig.prototype, "accessories", {
     get: function() {
-        return this._oClothingPattern;
-    }
-} );
-
-Object.defineProperty( DthAutoToolExportPatternsConfig.prototype, "grooming", {
-    get: function() {
-        return this._oGroomingPattern;
+        return this._oAccessoriesPattern;
     }
 } );
 
@@ -107,8 +101,7 @@ Object.defineProperty( DthAutoToolExportPatternsConfig.prototype, "layers", {
 DthAutoToolExportPatternsConfig.prototype.load = function( oExportPatternsConfig ) {
     this._oExportablesPattern = null;
     this._oTemplatesPattern = null;
-    this._oClothingPattern = null;
-    this._oGroomingPattern = null;
+    this._oAccessoriesPattern = null;
     this._oLayersPattern = null;
     
     if( !oExportPatternsConfig ) { return; }
@@ -121,13 +114,9 @@ DthAutoToolExportPatternsConfig.prototype.load = function( oExportPatternsConfig
         var sPattern = Cast.AsNotNullOrEmpty( oExportPatternsConfig.templates, "Templates export pattern must be a regexp string" );
         this._oTemplatesPattern = new RegExp( sPattern );
     }
-    if( oExportPatternsConfig.clothing && oExportPatternsConfig.clothing !== "" ) {
-        var sPattern = Cast.AsNotNullOrEmpty( oExportPatternsConfig.clothing, "Clothing export pattern must be a regexp string" );
-        this._oClothingPattern = new RegExp( sPattern );
-    }
-    if( oExportPatternsConfig.grooming && oExportPatternsConfig.grooming !== "" ) {
-        var sPattern = Cast.AsNotNullOrEmpty( oExportPatternsConfig.grooming, "Grooming export pattern must be a regexp string" );
-        this._oGroomingPattern = new RegExp( sPattern );
+    if( oExportPatternsConfig.accessories && oExportPatternsConfig.accessories !== "" ) {
+        var sPattern = Cast.AsNotNullOrEmpty( oExportPatternsConfig.accessories, "Accessories export pattern must be a regexp string" );
+        this._oAccessoriesPattern = new RegExp( sPattern );
     }
     if( oExportPatternsConfig.layers && oExportPatternsConfig.layers !== "" ) {
         var sPattern = Cast.AsNotNullOrEmpty( oExportPatternsConfig.layers, "Layers export pattern must be a regexp string" );
@@ -741,24 +730,23 @@ DthAutoToolConfiguration.prototype.build = function( sName ) {
         }
     }
 
-    // filter clothings by Clothing pattern
+    // filter accessories by Accessories pattern
     var mClothingLayerGroupsToExport = mProperties.get( "clothing" );
-    if( bNotInEditMode && oExportPatterns.clothing && !oExportPatterns.clothing !== "" ) {
+    var mGroomingLayerGroupsToExport = mProperties.get( "grooming" );
+    if( bNotInEditMode && oExportPatterns.accessories && !oExportPatterns.accessories !== "" ) {
+        // filter clothing
         var aClothingLayerGroupsKeys = mClothingLayerGroupsToExport.keys();
         for( var i=0; i<aClothingLayerGroupsKeys.length; i+=1 ) {
-            if( !oExportPatterns.clothing.test( aClothingLayerGroupsKeys[ i ] ) ) {
+            if( !oExportPatterns.accessories.test( aClothingLayerGroupsKeys[ i ] ) ) {
                 print( "Skipping exportable: '%1' clothing: '%2' due to 'clothing' pattern".arg( sName ).arg( i ) );
                 mClothingLayerGroupsToExport.remove( aClothingLayerGroupsKeys[ i ] );
             }
         }
-    }
 
-    // filter groomings by Grooming pattern
-    var mGroomingLayerGroupsToExport = mProperties.get( "grooming" );
-    if( bNotInEditMode && oExportPatterns.grooming && !oExportPatterns.grooming !== "" ) {
+        // filter grooming
         var aGroomingLayerGroupsKeys = mGroomingLayerGroupsToExport.keys();
         for( var i=0; i<aGroomingLayerGroupsKeys.length; i+=1 ) {
-            if( !oExportPatterns.grooming.test( aGroomingLayerGroupsKeys[ i ] ) ) {
+            if( !oExportPatterns.accessories.test( aGroomingLayerGroupsKeys[ i ] ) ) {
                 print( "Skipping exportable: '%1' grooming: '%2' due to 'grooming' pattern".arg( sName ).arg( i ) );
                 mGroomingLayerGroupsToExport.remove( aGroomingLayerGroupsKeys[ i ] );
             }

--- a/scripts/dth_at_config.dsa
+++ b/scripts/dth_at_config.dsa
@@ -59,7 +59,7 @@ DthAutoToolEditModeConfig.prototype.load = function( oConfig ) {
     }
 
     if( oConfig.grooming_name ) {
-        this._sGroomingName = oConfig.grooming_name
+        this._sGroomingName = oConfig.grooming_name;
         this._bWithGrooming = true;
     }
 
@@ -755,7 +755,7 @@ DthAutoToolConfiguration.prototype.build = function( sName ) {
 
     // filter groomings by Grooming pattern
     var mGroomingLayerGroupsToExport = mProperties.get( "grooming" );
-    if( bNotInEditMode && oExportPatterns.clothing && !oExportPatterns.clothing !== "" ) {
+    if( bNotInEditMode && oExportPatterns.grooming && !oExportPatterns.grooming !== "" ) {
         var aGroomingLayerGroupsKeys = mGroomingLayerGroupsToExport.keys();
         for( var i=0; i<aGroomingLayerGroupsKeys.length; i+=1 ) {
             if( !oExportPatterns.grooming.test( aGroomingLayerGroupsKeys[ i ] ) ) {
@@ -796,8 +796,8 @@ DthAutoToolConfiguration.prototype.build = function( sName ) {
 
 /*********************************************************************/
 // DthAutoToolExportable constructor
-function DthAutoToolExportPlan( sName, mCharacter, mClothing, mMorphs ) {
-    this.load( sName, mCharacter, mClothing, mMorphs );
+function DthAutoToolExportPlan( sName, mCharacter, mClothing, mGrooming, mMorphs ) {
+    this.load( sName, mCharacter, mClothing, mGrooming, mMorphs );
 }
 
 Object.defineProperty( DthAutoToolExportPlan.prototype, "name", {

--- a/scripts/dth_at_config.dsa
+++ b/scripts/dth_at_config.dsa
@@ -30,6 +30,18 @@ Object.defineProperty( DthAutoToolEditModeConfig.prototype, "withClothing", {
     }
 } );
 
+Object.defineProperty( DthAutoToolEditModeConfig.prototype, "groomingName", {
+    get: function() {
+        return this._sGroomingName;
+    }
+} );
+
+Object.defineProperty( DthAutoToolEditModeConfig.prototype, "withGrooming", {
+    get: function() {
+        return this._bWithGrooming;
+    }
+} );
+
 /*********************************************************************/
 // Function to load & validate edit mode given available exportables
 DthAutoToolEditModeConfig.prototype.load = function( oConfig ) {
@@ -44,6 +56,11 @@ DthAutoToolEditModeConfig.prototype.load = function( oConfig ) {
     if( oConfig.clothing_name ) {
         this._sClothingName = oConfig.clothing_name
         this._bWithClothing = true;
+    }
+
+    if( oConfig.grooming_name ) {
+        this._sGroomingName = oConfig.grooming_name
+        this._bWithGrooming = true;
     }
 
     this._bIsEnabled = true;
@@ -73,6 +90,12 @@ Object.defineProperty( DthAutoToolExportPatternsConfig.prototype, "clothing", {
     }
 } );
 
+Object.defineProperty( DthAutoToolExportPatternsConfig.prototype, "grooming", {
+    get: function() {
+        return this._oGroomingPattern;
+    }
+} );
+
 Object.defineProperty( DthAutoToolExportPatternsConfig.prototype, "layers", {
     get: function() {
         return this._oLayersPattern;
@@ -85,6 +108,7 @@ DthAutoToolExportPatternsConfig.prototype.load = function( oExportPatternsConfig
     this._oExportablesPattern = null;
     this._oTemplatesPattern = null;
     this._oClothingPattern = null;
+    this._oGroomingPattern = null;
     this._oLayersPattern = null;
     
     if( !oExportPatternsConfig ) { return; }
@@ -100,6 +124,10 @@ DthAutoToolExportPatternsConfig.prototype.load = function( oExportPatternsConfig
     if( oExportPatternsConfig.clothing && oExportPatternsConfig.clothing !== "" ) {
         var sPattern = Cast.AsNotNullOrEmpty( oExportPatternsConfig.clothing, "Clothing export pattern must be a regexp string" );
         this._oClothingPattern = new RegExp( sPattern );
+    }
+    if( oExportPatternsConfig.grooming && oExportPatternsConfig.grooming !== "" ) {
+        var sPattern = Cast.AsNotNullOrEmpty( oExportPatternsConfig.grooming, "Grooming export pattern must be a regexp string" );
+        this._oGroomingPattern = new RegExp( sPattern );
     }
     if( oExportPatternsConfig.layers && oExportPatternsConfig.layers !== "" ) {
         var sPattern = Cast.AsNotNullOrEmpty( oExportPatternsConfig.layers, "Layers export pattern must be a regexp string" );
@@ -299,7 +327,7 @@ function DthAutoToolBaseTemplate( oConfig ) {
 /*********************************************************************/
 // All possible operation modes to choose from
 DthAutoToolBaseTemplate.LayerGroupsProperties = {
-    Categories: [ "character", "morphs", "clothing" ],
+    Categories: [ "character", "morphs", "clothing", "grooming" ],
     ExtOptions: [ "append", "prepend", "override" ]
 };
 
@@ -321,6 +349,12 @@ Object.defineProperty( DthAutoToolBaseTemplate.prototype, "clothingLayerGroups",
     }
 } );
 
+Object.defineProperty( DthAutoToolBaseTemplate.prototype, "groomingLayerGroups", {
+    get: function() {
+        return this._mGroomingLayerGroups;
+    }
+} );
+
 Object.defineProperty( DthAutoToolBaseTemplate.prototype, "morphsLayerGroups", {
     get: function() {
         return this._mMorphsLayerGroups;
@@ -333,7 +367,6 @@ DthAutoToolBaseTemplate.prototype.load = function( oConfig ) {
     this._sName = Cast.AsNotNullOrEmpty( oConfig.name, "Valid name must be provided for template" );
 
     var aLayerGroupsProperties = DthAutoToolBaseTemplate.LayerGroupsProperties.Categories;
-    var aLayerGroupsPropertiesPrefixes = DthAutoToolBaseTemplate.LayerGroupsProperties.ExtOptions;
 
     for ( var i = 0; i<aLayerGroupsProperties.length; i++ ) {
         var sBasePropName = aLayerGroupsProperties[ i ];
@@ -405,6 +438,22 @@ Object.defineProperty( DthAutoToolExportable.prototype, "overrideClothingLayerGr
 Object.defineProperty( DthAutoToolExportable.prototype, "appendClothingLayerGroups", {
     get: function() {
         return this._mAppendClothingLayerGroups;
+    }
+} );
+
+Object.defineProperty( DthAutoToolExportable.prototype, "prependGroomingLayerGroups", {
+    get: function() {
+        return this._mPrependGroomingLayerGroups;
+    }
+} );
+Object.defineProperty( DthAutoToolExportable.prototype, "overrideGroomingLayerGroups", {
+    get: function() {
+        return this._mOverrideGroomingLayerGroups;
+    }
+} );
+Object.defineProperty( DthAutoToolExportable.prototype, "appendGroomingLayerGroups", {
+    get: function() {
+        return this._mAppendGroomingLayerGroups;
     }
 } );
 
@@ -698,13 +747,25 @@ DthAutoToolConfiguration.prototype.build = function( sName ) {
         var aClothingLayerGroupsKeys = mClothingLayerGroupsToExport.keys();
         for( var i=0; i<aClothingLayerGroupsKeys.length; i+=1 ) {
             if( !oExportPatterns.clothing.test( aClothingLayerGroupsKeys[ i ] ) ) {
-                print( "Skipping exportables: '%1' clothing: '%2' due to 'clothing' pattern".arg( sName ).arg( i ) );
+                print( "Skipping exportable: '%1' clothing: '%2' due to 'clothing' pattern".arg( sName ).arg( i ) );
                 mClothingLayerGroupsToExport.remove( aClothingLayerGroupsKeys[ i ] );
             }
         }
     }
 
-    var oExportPlan = new DthAutoToolExportPlan( sName, mProperties.get( "character" ), mClothingLayerGroupsToExport, mProperties.get( "morphs" ) );
+    // filter groomings by Grooming pattern
+    var mGroomingLayerGroupsToExport = mProperties.get( "grooming" );
+    if( bNotInEditMode && oExportPatterns.clothing && !oExportPatterns.clothing !== "" ) {
+        var aGroomingLayerGroupsKeys = mGroomingLayerGroupsToExport.keys();
+        for( var i=0; i<aGroomingLayerGroupsKeys.length; i+=1 ) {
+            if( !oExportPatterns.grooming.test( aGroomingLayerGroupsKeys[ i ] ) ) {
+                print( "Skipping exportable: '%1' grooming: '%2' due to 'grooming' pattern".arg( sName ).arg( i ) );
+                mGroomingLayerGroupsToExport.remove( aGroomingLayerGroupsKeys[ i ] );
+            }
+        }
+    }
+
+    var oExportPlan = new DthAutoToolExportPlan( sName, mProperties.get( "character" ), mClothingLayerGroupsToExport, mGroomingLayerGroupsToExport, mProperties.get( "morphs" ) );
 
     // filter by Layer (duf file or asset) name
     if( bNotInEditMode && oExportPatterns.layers && !oExportPatterns.layers !== "" ) {
@@ -714,8 +775,11 @@ DthAutoToolConfiguration.prototype.build = function( sName ) {
         var aClothingLayers = oExportPlan.clothing.reduce( function( r, s ) {
             return r.concat( s.layers.reduce( function( u, v ) { return u.concat( v ); }, [] ) );
         }, [] );
+        var aGroomingLayers = oExportPlan.grooming.reduce( function( r, s ) {
+            return r.concat( s.layers.reduce( function( u, v ) { return u.concat( v ); }, [] ) );
+        }, [] );
         
-        var aLayers = aCharacterLayers.concat( aMorphsLayers ).concat( aClothingLayers );
+        var aLayers = aCharacterLayers.concat( aMorphsLayers ).concat( aClothingLayers ).concat( aGroomingLayers );
 
         for( var i=0; i<aLayers.length; i+=1 ) {
             if( oExportPatterns.layers.test( aLayers[ i ] ) ) {
@@ -760,6 +824,15 @@ Object.defineProperty( DthAutoToolExportPlan.prototype, "clothing", {
     }
 } );
 
+Object.defineProperty( DthAutoToolExportPlan.prototype, "grooming", {
+    get: function() {
+        if( !this._cachedGroomingLayerGroups ) {
+            this._cachedGroomingLayerGroups = this._groomingLayerGroups.values();
+        }
+        return this._cachedGroomingLayerGroups;
+    }
+} );
+
 Object.defineProperty( DthAutoToolExportPlan.prototype, "morphs", {
     get: function() {
         if( !this._cachedMorphsLayers ) {
@@ -771,15 +844,17 @@ Object.defineProperty( DthAutoToolExportPlan.prototype, "morphs", {
 
 /*********************************************************************/
 // Function to populate internal layer groups variables.
-DthAutoToolExportPlan.prototype.load = function( sName, mCharacter, mClothing, mMorphs ) {
+DthAutoToolExportPlan.prototype.load = function( sName, mCharacter, mClothing, mGrooming, mMorphs ) {
     this._sName = Cast.AsNotNullOrEmpty( sName, "Exportable plan name must not be null or empty" );
 
     this._characterLayerGroups = mCharacter;
     this._clothingLayerGroups = mClothing;
+    this._groomingLayerGroups = mGrooming;
     this._morphsLayerGroups = mMorphs;
 
     // clear cache
+    this._cachedCharacterLayers = null;
     this._cachedClothingLayerGroups = null;
-    this._cachedClothingLayerGroups = null;
-    this._cachedMorphsLayerGroups = null;
+    this._cachedGroomingLayerGroups = null;
+    this._cachedMorphsLayers = null;
 };

--- a/scripts/dth_at_config.dsa
+++ b/scripts/dth_at_config.dsa
@@ -738,7 +738,7 @@ DthAutoToolConfiguration.prototype.build = function( sName ) {
         var aClothingLayerGroupsKeys = mClothingLayerGroupsToExport.keys();
         for( var i=0; i<aClothingLayerGroupsKeys.length; i+=1 ) {
             if( !oExportPatterns.accessories.test( aClothingLayerGroupsKeys[ i ] ) ) {
-                print( "Skipping exportable: '%1' clothing: '%2' due to 'clothing' pattern".arg( sName ).arg( i ) );
+                print( "Skipping exportable: '%1' clothing: '%2' due to 'accessories' pattern".arg( sName ).arg( aClothingLayerGroupsKeys[ i ] ) );
                 mClothingLayerGroupsToExport.remove( aClothingLayerGroupsKeys[ i ] );
             }
         }
@@ -747,7 +747,7 @@ DthAutoToolConfiguration.prototype.build = function( sName ) {
         var aGroomingLayerGroupsKeys = mGroomingLayerGroupsToExport.keys();
         for( var i=0; i<aGroomingLayerGroupsKeys.length; i+=1 ) {
             if( !oExportPatterns.accessories.test( aGroomingLayerGroupsKeys[ i ] ) ) {
-                print( "Skipping exportable: '%1' grooming: '%2' due to 'grooming' pattern".arg( sName ).arg( i ) );
+                print( "Skipping exportable: '%1' grooming: '%2' due to 'accessories' pattern".arg( sName ).arg( aGroomingLayerGroupsKeys[ i ] ) );
                 mGroomingLayerGroupsToExport.remove( aGroomingLayerGroupsKeys[ i ] );
             }
         }

--- a/scripts/dth_at_exporter.dsa
+++ b/scripts/dth_at_exporter.dsa
@@ -182,7 +182,7 @@ DthAutoToolExporter.prototype.init = function( oExportPlan, oDthAutoToolConfig, 
     this._aMorphsAssets = [];
     this._nCurrentClothingIndex = -1;
     this._mClothingAssets = new OrderedKeyValueSet();
-    this._mClothingAssets = new OrderedKeyValueSet();
+    this._mGroomingAssets = new OrderedKeyValueSet();
 
     var oLibBrowser = new DthAutoToolLibraryBrowser();
 
@@ -389,7 +389,7 @@ DthAutoToolExporter.prototype.loadClothing = function( sClothing ) {
 
 /*********************************************************************/
 // Function to check if exportable contains clothing layer group with given name
-DthAutoToolExporter.prototype.loadGrooming = function( sGrooming ) {
+DthAutoToolExporter.prototype.loadGrooming = function( sGrooming, bHideCharacter ) {
     print( "Loading grooming layers \"%1\" for exportable \"%2\"".arg( sGrooming ).arg( this.exportableName ) );
 
     if( !this._oPrimaryFigure ) {
@@ -402,10 +402,12 @@ DthAutoToolExporter.prototype.loadGrooming = function( sGrooming ) {
     }
     var aGroomingAssets = this._mGroomingAssets.get( sGrooming );
 
-    // setup invisibility on all nodes before loading groom layers
-    var aNonGroomNodes = Scene.getNodeList();
-    for( var i=0; i<aNonGroomNodes.length; i+=1 ) {
-        aNonGroomNodes[ i ].setVisible( false );
+    // setup invisibility on all nodes before loading groom layers when exporting
+    if( bHideCharacter ) {
+        var aNonGroomNodes = Scene.getNodeList();
+        for( var i=0; i<aNonGroomNodes.length; i+=1 ) {
+            aNonGroomNodes[ i ].setVisible( false );
+        }
     }
 
     var oContentMgr = App.getContentMgr();

--- a/scripts/dth_at_exporter.dsa
+++ b/scripts/dth_at_exporter.dsa
@@ -13,6 +13,7 @@ function DthAutoToolHandler( oConfig ) {
 DthAutoToolHandler.OpModes = {
     LoadCharacter: "AutoConfirm/LoadCharacter",
     LoadClothing: "AutoConfirm/LoadCharacter",
+    LoadGrooming: "AutoConfirm/LoadCharacter",
     LoadAnimation: "AutoConfirm/ResizeTimeline",
     ExportSaganAlembicV3: "AlembicExport/HandleDialog",
     ExportDazToMayaFbx: "DazToMaya/HandleDialog"
@@ -158,6 +159,10 @@ Object.defineProperty( DthAutoToolExporter.prototype, "clothings", {
     get: function() { return this._mClothingAssets.keys(); }
 } );
 
+Object.defineProperty( DthAutoToolExporter.prototype, "groomings", {
+    get: function() { return this._mGroomingAssets.keys(); }
+} );
+
 Object.defineProperty( DthAutoToolExporter.prototype, "exportableName", {
     get: function() { return this._oExportPlan.name; }
 } );
@@ -176,6 +181,7 @@ DthAutoToolExporter.prototype.init = function( oExportPlan, oDthAutoToolConfig, 
     this._aCharacterAssets = [];
     this._aMorphsAssets = [];
     this._nCurrentClothingIndex = -1;
+    this._mClothingAssets = new OrderedKeyValueSet();
     this._mClothingAssets = new OrderedKeyValueSet();
 
     var oLibBrowser = new DthAutoToolLibraryBrowser();
@@ -213,6 +219,21 @@ DthAutoToolExporter.prototype.init = function( oExportPlan, oDthAutoToolConfig, 
             }
         }
         this._mClothingAssets.add( oClothingLayerGroup.name, aClothingLayerGroupAssets );
+    }
+
+    for( var t=0; t<this._oExportPlan.grooming.length; t+=1 ) {
+        var oGroomingLayerGroup = this._oExportPlan.grooming[ t ];
+        var aGroomingLayerGroupAssets = [];
+        for( var l=0; l<oGroomingLayerGroup.layers.length; l+=1 ) {
+            var sAssetNamePattern = oGroomingLayerGroup.layers[ l ];
+            var oAsset = oLibBrowser.search( sAssetNamePattern );
+            if( oAsset ) {
+                aGroomingLayerGroupAssets.push( oAsset );
+            } else {
+                throw new Error( "Asset not found: %1".arg( sAssetNamePattern ) );
+            }
+        }
+        this._mGroomingAssets.add( oGroomingLayerGroup.name, aGroomingLayerGroupAssets );
     }
 };
 
@@ -367,8 +388,41 @@ DthAutoToolExporter.prototype.loadClothing = function( sClothing ) {
 };
 
 /*********************************************************************/
+// Function to check if exportable contains clothing layer group with given name
+DthAutoToolExporter.prototype.loadGrooming = function( sGrooming ) {
+    print( "Loading grooming layers \"%1\" for exportable \"%2\"".arg( sGrooming ).arg( this.exportableName ) );
+
+    if( !this._oPrimaryFigure ) {
+        throw new Error( "Character not loaded yet - primary figure not found" );
+    }
+
+    Assert.NotNullOrEmpty( sGrooming );
+    if( !this._mGroomingAssets.has( sGrooming ) ) {
+        throw new Error( "Grooming assets not found: %1".arg( sGrooming ) );
+    }
+    var aGroomingAssets = this._mGroomingAssets.get( sGrooming );
+
+    // setup invisibility on all nodes before loading groom layers
+    var aNonGroomNodes = Scene.getNodeList();
+    for( var i=0; i<aNonGroomNodes.length; i+=1 ) {
+        aNonGroomNodes[ i ].setVisible( false );
+    }
+
+    var oContentMgr = App.getContentMgr();
+
+    for( var c=0; c<aGroomingAssets.length; c+=1 ) {
+        var oGroomingAsset = aGroomingAssets[ c ];
+        print( "Loading grooming asset: %1".arg( oGroomingAsset.assetName ) );
+        function callback() {
+            oContentMgr.loadAsset( oGroomingAsset, true );
+        }
+        this._oDthAutoToolHandler.run( DthAutoToolHandler.OpModes.LoadGrooming, callback, false, null );
+    }
+};
+
+/*********************************************************************/
 // Prepare all subdivision levels to be ready for DTH workflow
-DthAutoToolExporter.prototype.setupSubdivisionLevels = function() {
+DthAutoToolExporter.prototype.setupSubdivisionLevels = function( nSubDLevel ) {
     if( !this._oPrimaryFigure ) {
         throw new Error( "Character not loaded yet - primary figure not found" );
     }
@@ -390,7 +444,7 @@ DthAutoToolExporter.prototype.setupSubdivisionLevels = function() {
                 var oPropSubDLevel = oPrimaryFigureShape.findProperty( "SubDIALevel" );
                 if( oPropSubDLevel ) {
                     bHasSubDProperty = true;
-                    oPropSubDLevel.setValue( 1 );
+                    oPropSubDLevel.setValue( nSubDLevel );
                 }
 
                 var oPropRenderSubDLevel= oPrimaryFigureShape.findProperty( "SubDRenderLevel" );
@@ -398,7 +452,7 @@ DthAutoToolExporter.prototype.setupSubdivisionLevels = function() {
                     bHasSubDProperty = true;
                     // NOTE: from some reason, "SubDRenderLevel" setValue sets the actual
                     //   integer value to the parameter + 1, therefore passing 0 value
-                    oPropRenderSubDLevel.setValue( 0 );
+                    oPropRenderSubDLevel.setValue( nSubDLevel-1 );
                 }
 
                 if ( bHasSubDProperty ) {
@@ -469,33 +523,41 @@ DthAutoToolExporter.prototype.prepareScene = function() {
 
 /*********************************************************************/
 // Function to export loaded assets
-DthAutoToolExporter.prototype.startExport = function( sClothing ) {
+DthAutoToolExporter.prototype.startExport = function( nSubDLevel, bExportFbx, bExportAbc ) {
     print( "Exporting \"%1\"".arg( this.exportableName ) );
 
-    var nSubDNodesCount = this.setupSubdivisionLevels();
+    if( nSubDLevel < 0 ) {
+        nSubDLevel = 0;
+    }
+
+    var nSubDNodesCount = this.setupSubdivisionLevels( nSubDLevel );
     
     // viewport must be visible in order for sagan alembic exporter to work properly
     DzHelpers.ShowPane( "DzViewportMgrPane" );
 
     Scene.setFrame( 0 );
-    var oSaganAlembicExporterAction = DzHelpers.GetAction( "Sagan Alembic Exporter v3" );
-    function fSaganAlembicExportCallback() {
-        oSaganAlembicExporterAction.trigger();
-    }
-    var mSaganAlembicExporterParams = new OrderedKeyValueSet();
+    if( bExportAbc ) {
+        var oSaganAlembicExporterAction = DzHelpers.GetAction( "Sagan Alembic Exporter v3" );
+        function fSaganAlembicExportCallback() {
+            oSaganAlembicExporterAction.trigger();
+        }
+        var mSaganAlembicExporterParams = new OrderedKeyValueSet();
 
-    mSaganAlembicExporterParams.add( DthAutoToolHandler.CmdParams.SaganAlembicExporterOutputPath, this._oExportSettings.saganAlembicExportDirAbsPath );
-    mSaganAlembicExporterParams.add( DthAutoToolHandler.CmdParams.SaganAlembicExporterEndFrame, DzHelpers.GetPlayRangeEndFrame() );
-    this._oDthAutoToolHandler.run( DthAutoToolHandler.OpModes.ExportSaganAlembicV3, fSaganAlembicExportCallback, false, mSaganAlembicExporterParams );
-
-    var oSendToMayaAction = DzHelpers.GetAction( "Send to Maya" );
-    function fSendToMayaExportCallback() {
-        oSendToMayaAction.trigger();
+        mSaganAlembicExporterParams.add( DthAutoToolHandler.CmdParams.SaganAlembicExporterOutputPath, this._oExportSettings.saganAlembicExportDirAbsPath );
+        mSaganAlembicExporterParams.add( DthAutoToolHandler.CmdParams.SaganAlembicExporterEndFrame, DzHelpers.GetPlayRangeEndFrame() );
+        this._oDthAutoToolHandler.run( DthAutoToolHandler.OpModes.ExportSaganAlembicV3, fSaganAlembicExportCallback, false, mSaganAlembicExporterParams );
     }
-    var mSendToMayaParams = new OrderedKeyValueSet();
-    mSendToMayaParams.add( DthAutoToolHandler.CmdParams.ExportAssetName, this._oExportPlan.name );
-    mSendToMayaParams.add( DthAutoToolHandler.CmdParams.SubDivisionShapesCount, nSubDNodesCount );
-    this._oDthAutoToolHandler.run( DthAutoToolHandler.OpModes.ExportDazToMayaFbx, fSendToMayaExportCallback, false, mSendToMayaParams );
+
+    if( bExportFbx ) {
+        var oSendToMayaAction = DzHelpers.GetAction( "Send to Maya" );
+        function fSendToMayaExportCallback() {
+            oSendToMayaAction.trigger();
+        }
+        var mSendToMayaParams = new OrderedKeyValueSet();
+        mSendToMayaParams.add( DthAutoToolHandler.CmdParams.ExportAssetName, this._oExportPlan.name );
+        mSendToMayaParams.add( DthAutoToolHandler.CmdParams.SubDivisionShapesCount, nSubDNodesCount );
+        this._oDthAutoToolHandler.run( DthAutoToolHandler.OpModes.ExportDazToMayaFbx, fSendToMayaExportCallback, false, mSendToMayaParams );
+    }
 
     DzHelpers.ShowPane( "DzScriptPane" );
 };

--- a/scripts/dth_at_project_loader.dsa
+++ b/scripts/dth_at_project_loader.dsa
@@ -34,6 +34,10 @@ function ExecuteSteps( aSteps ) {
         {
             oDthAutoToolExporter.loadClothing( oDthAutoToolConfig.editMode.clothingName );
         }
+        if( oDthAutoToolConfig.editMode.withGrooming )
+        {
+            oDthAutoToolExporter.loadGrooming( oDthAutoToolConfig.editMode.groomingName );
+        }
         oDthAutoToolExporter.loadMorphs();
         
         DzHelpers.ShowPane( "DzViewportMgrPane" );
@@ -66,12 +70,12 @@ function ExecuteSteps( aSteps ) {
             var oDthAutoToolExporter = new DthAutoToolExporter( oExportPlan, oDthAutoToolConfig.dthAutoToolConfig, oDthAutoToolConfig.exportSettings );
 
             if( !oDthAutoToolConfig.exportSettings.skipBaseModel ) {
-                // export base character without clothings
+                // export base character only
                 if( !ExecuteSteps( [
                     function() { oDthAutoToolExporter.prepareScene(); },
                     function() { oDthAutoToolExporter.loadCharacter(); },
                     function() { oDthAutoToolExporter.loadMorphs(); },
-                    function() { oDthAutoToolExporter.startExport(); },
+                    function() { oDthAutoToolExporter.startExport( 1, true, true ); },
                     function() { oDthAutoToolExporter.copyResult( sOutputName ); }
                 ] ) ) { break; }
                 
@@ -87,8 +91,22 @@ function ExecuteSteps( aSteps ) {
                         function() { oDthAutoToolExporter.loadCharacter(); },
                         function() { oDthAutoToolExporter.loadClothing( aClothingKeys[ j ] ); },
                         function() { oDthAutoToolExporter.loadMorphs(); },
-                        function() { oDthAutoToolExporter.startExport(); },
+                        function() { oDthAutoToolExporter.startExport( 1, true, true ); },
                         function() { oDthAutoToolExporter.copyResult( "%1 - %2".arg( sOutputName ).arg( aClothingKeys[ j ] ) ); }
+                    ] ) ) { break; }
+                }
+            }
+
+            // if groomings defined each grooming set
+            var aGroomingKeys = oDthAutoToolExporter.groomings;
+            if( aGroomingKeys.length > 0 ) {
+                for( var j=0; j<aGroomingKeys.length; j+=1 ) {
+                    if( !ExecuteSteps( [
+                        function() { oDthAutoToolExporter.prepareScene(); },
+                        function() { oDthAutoToolExporter.loadCharacter(); },
+                        function() { oDthAutoToolExporter.loadGrooming( aGroomingKeys[ j ] ); },
+                        function() { oDthAutoToolExporter.startExport( 0, false, true ); },
+                        function() { oDthAutoToolExporter.copyResult( "%1 - %2".arg( sOutputName ).arg( aGroomingKeys[ j ] ) ); }
                     ] ) ) { break; }
                 }
             }

--- a/scripts/dth_at_project_loader.dsa
+++ b/scripts/dth_at_project_loader.dsa
@@ -54,7 +54,7 @@ function ExecuteSteps( aSteps ) {
             aExportPlans.push( oExportPlan );
 
             if( !oDthAutoToolConfig.exportSettings.skipBaseModel ) { iTotalExportSteps += 1; }
-            iTotalExportSteps += oExportPlan.clothing.length;
+            iTotalExportSteps += oExportPlan.clothing.length + oExportPlan.clothing.length;
         }
 
         startProgress( text( "DTH-AutoTool export progress" ), iTotalExportSteps, true, true );

--- a/scripts/dth_at_project_loader.dsa
+++ b/scripts/dth_at_project_loader.dsa
@@ -36,7 +36,7 @@ function ExecuteSteps( aSteps ) {
         }
         if( oDthAutoToolConfig.editMode.withGrooming )
         {
-            oDthAutoToolExporter.loadGrooming( oDthAutoToolConfig.editMode.groomingName );
+            oDthAutoToolExporter.loadGrooming( oDthAutoToolConfig.editMode.groomingName, false );
         }
         oDthAutoToolExporter.loadMorphs();
         
@@ -104,7 +104,7 @@ function ExecuteSteps( aSteps ) {
                     if( !ExecuteSteps( [
                         function() { oDthAutoToolExporter.prepareScene(); },
                         function() { oDthAutoToolExporter.loadCharacter(); },
-                        function() { oDthAutoToolExporter.loadGrooming( aGroomingKeys[ j ] ); },
+                        function() { oDthAutoToolExporter.loadGrooming( aGroomingKeys[ j ], true ); },
                         function() { oDthAutoToolExporter.startExport( 0, false, true ); },
                         function() { oDthAutoToolExporter.copyResult( "%1 - %2".arg( sOutputName ).arg( aGroomingKeys[ j ] ) ); }
                     ] ) ) { break; }

--- a/templates/template.project.config.json
+++ b/templates/template.project.config.json
@@ -3,7 +3,8 @@
     "edit_mode": {
         "is_enabled": false,
         "exportable_name": "",
-        "clothing_name": ""
+        "clothing_name": "",
+        "grooming_name": ""
     },
     "export_settings": {
         "skip_base_model": false,
@@ -11,6 +12,7 @@
             "exportables": "",
             "templates": "",
             "clothing": "",
+            "grooming": "",
             "layers": ""
         },
         "sagan_alembic_export_directory": "",
@@ -24,20 +26,29 @@
     },
     "templates": [
         {
-            "name": "Default Female",
-            "character": [ { "name": "Genesis 8.1 Basic Female", "layers": ["genesis 8.1 basic female.duf"] } ],
-            "clothing": [ { "name": "Basic Female Wear", "layers": ["basic wear tank top.duf", "basic wear shorts.duf"] } ],
+            "name": "Default Male",
+            "character": [ { "name": "Genesis 8.1 Male", "layers": ["genesis 8.1 basic male.duf"] } ],
             "morphs": [ { "name": "DTH", "layers": ["G8.1 LINEAR JCM - Base.duf"] } ]
         },
         {
-            "name": "Default Male",
-            "character": [ { "name": "Genesis 8.1 Male", "layers": ["genesis 8.1 basic male.duf"] } ],
-            "clothing": [ { "name": "Basic Male Wear", "layers": ["basic wear t shirt.duf", "basic wear boxers.duf"] } ],
+            "name": "Default Female",
+            "character": [ { "name": "Genesis 8.1 Basic Female", "layers": ["genesis 8.1 basic female.duf"] } ],
             "morphs": [ { "name": "DTH", "layers": ["G8.1 LINEAR JCM - Base.duf"] } ]
+        },
+
+        {
+            "name": "Default Male Accessories",
+            "clothing": [ { "name": "Basic Male Wear", "layers": ["basic wear t shirt.duf", "basic wear boxers.duf"] } ],
+            "grooming": [ { "name": "Basic Male Hair", "layers": ["Armani Hair.duf"] } ]
+        },
+        {
+            "name": "Default Female Accessories",
+            "clothing": [ { "name": "Basic Female Wear", "layers": ["basic wear tank top.duf", "basic wear shorts.duf"] } ],
+            "grooming": [ { "name": "Basic Female Hair", "layers": ["Toulouse Hair.duf"] } ]
         }
     ],
     "exportables": [
-        { "name": "Adam", "templates": ["Default Male"] },
-        { "name": "Eve", "templates": ["Default Female"] }
+        { "name": "Adam", "templates": [ "Default Male", "Default Male Accessories" ] },
+        { "name": "Eve", "templates": [ "Default Female", "Default Female Accessories" ] }
     ]
 }

--- a/templates/template.project.config.json
+++ b/templates/template.project.config.json
@@ -10,7 +10,7 @@
         "export_patterns": {
             "exportables": "",
             "templates": "",
-            "clothing": "",
+            "accessories": "",
             "layers": ""
         },
         "sagan_alembic_export_directory": "",

--- a/templates/template.project.config.json
+++ b/templates/template.project.config.json
@@ -1,10 +1,9 @@
 {
-    "version": "0.1",
+    "version": "0.2",
     "edit_mode": {
         "is_enabled": false,
         "exportable_name": "",
-        "clothing_name": "",
-        "grooming_name": ""
+        "clothing_name": ""
     },
     "export_settings": {
         "skip_base_model": false,
@@ -12,7 +11,6 @@
             "exportables": "",
             "templates": "",
             "clothing": "",
-            "grooming": "",
             "layers": ""
         },
         "sagan_alembic_export_directory": "",


### PR DESCRIPTION
Added ability to export grooming assets (hair, beard, ...) as alembic cache.
Merged clothing and grooming filters to a single accessories filter as they both act as filter for a solo asset export.